### PR TITLE
fix to pc and spaces in path

### DIFF
--- a/jigsaw.m
+++ b/jigsaw.m
@@ -303,8 +303,7 @@ function [varargout] = jigsaw(opts)
     if (exist(jexename,'file')==2)
 
    [status, result] = system( ...
-        [jexename,' ',opts.jcfg_file], '-echo');
-
+        ['"',jexename,'"',' ','"',opts.jcfg_file,'"'], '-echo');
 %---------------------------- OCTAVE doesn't handle '-echo'!
     if (exist('OCTAVE_VERSION', 'builtin') > 0)
         fprintf(1, '%s', result) ;


### PR DESCRIPTION
Call to jigsaw.exe will fail if there are spaces in the path to either the .exe or config file. 
Adding quotes fixes this behaviour. A better fix would add a check of this sort to all system calls and also only add quotes when they don't already exist.